### PR TITLE
Name search via TCP and put >16kB

### DIFF
--- a/src/com/cosylab/epics/caj/impl/CAJNameClient.java
+++ b/src/com/cosylab/epics/caj/impl/CAJNameClient.java
@@ -1,0 +1,96 @@
+package com.cosylab.epics.caj.impl;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.logging.Logger;
+
+import com.cosylab.epics.caj.CAJContext;
+import com.cosylab.epics.caj.impl.requests.VersionRequest;
+import com.cosylab.epics.caj.util.Timer;
+import com.cosylab.epics.caj.util.Timer.TimerRunnable;
+
+public class CAJNameClient implements TransportClient, TimerRunnable, Request {
+	Logger log = Logger.getLogger(CAJNameClient.class.getName());
+	
+	final CAJContext context;
+	final InetSocketAddress addr;
+	Transport transport;
+	Object reconnect;
+	public final ByteBuffer sendBuffer = ByteBuffer.allocateDirect(CAConstants.MAX_UDP_SEND);
+
+	public CAJNameClient(CAJContext ctxt, InetSocketAddress ep) {
+		context = ctxt;
+		addr = ep;
+		initBuffer();
+	}
+
+	public void initBuffer() {
+		sendBuffer.clear();
+	}
+	
+	public void connect() {
+		// initially give minor version=0, the allow client to replace when Version message is received
+		Transport trn = context.getTransport(this, addr, (short)0, (short)0);
+		if(trn!=null) {
+			transport = trn;
+			log.fine("Connected to name server "+addr.toString());
+		} else {
+			transportClosed(); // retry later
+		}
+	}
+
+	public void cancel() {
+		Object recon = reconnect;
+		if(recon!=null)
+			Timer.cancel(recon);
+	}
+
+	// from TimerRunnable	
+	
+	@Override
+	public void timeout(long timeToRun) {
+		reconnect = null;
+		connect();
+	}
+
+	// from TransportClient
+	
+	@Override
+	public void transportUnresponsive() {}
+
+	@Override
+	public void transportResponsive(Transport transport) {}
+
+	@Override
+	public void transportChanged() {}
+
+	@Override
+	public void transportClosed() {
+		transport = null;
+		//TODO: exponential backoff on retry
+		reconnect = context.getTimer().executeAfterDelay(10000, this);
+		log.fine("Lost connection to name server "+addr.toString());
+	}
+
+	// from Request
+	
+	@Override
+	public byte getPriority() {
+		// search requests have low priority
+		return Request.MIN_USER_PRIORITY;
+	}
+
+	@Override
+	public ByteBuffer getRequestMessage() {
+		return sendBuffer;
+	}
+
+	@Override
+	public void submit() throws IOException {
+		Transport trn = transport;
+		if(trn!=null) {
+			trn.submit(this);
+		}
+	}
+}

--- a/src/com/cosylab/epics/caj/impl/CATransport.java
+++ b/src/com/cosylab/epics/caj/impl/CATransport.java
@@ -352,6 +352,10 @@ public class CATransport implements Transport, ReactorHandler, Timer.TimerRunnab
 		return remoteTransportRevision;
 	}
 
+	public void setMinorRevision(short rev) {
+		remoteTransportRevision = rev;
+	}
+	
 	/**
 	 * Handle IO event.
 	 * @see com.cosylab.epics.caj.impl.reactor.ReactorHandler#handleEvent(java.nio.channels.SelectionKey)

--- a/src/com/cosylab/epics/caj/impl/handlers/SearchResponse.java
+++ b/src/com/cosylab/epics/caj/impl/handlers/SearchResponse.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import com.cosylab.epics.caj.CAJContext;
 import com.cosylab.epics.caj.impl.CAConstants;
+import com.cosylab.epics.caj.impl.CATransport;
 import com.cosylab.epics.caj.impl.Transport;
 import com.cosylab.epics.caj.util.InetAddressUtil;
 
@@ -60,6 +61,9 @@ public class SearchResponse extends AbstractCAJResponseHandler {
 		{ 
 			// UDP response (all in buffer 0)
 			minorVersion = response[0].getShort();
+		} else if(transport instanceof CATransport) {
+			// for TCP transport use already provided version
+			minorVersion = transport.getMinorRevision();
 		}
 			
 		// read rest of the playload (needed for UDP)
@@ -67,6 +71,8 @@ public class SearchResponse extends AbstractCAJResponseHandler {
 		
 		// signed short conversion -> signed int 
 		int port = dataType & 0xFFFF;
+		if(port<=0)
+			port = responseFrom.getPort();
 
 		// CA v4.8 or newer
 		if (minorVersion >= 8)

--- a/src/com/cosylab/epics/caj/impl/handlers/VersionResponse.java
+++ b/src/com/cosylab/epics/caj/impl/handlers/VersionResponse.java
@@ -18,6 +18,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 
 import com.cosylab.epics.caj.CAJContext;
+import com.cosylab.epics.caj.impl.CATransport;
 import com.cosylab.epics.caj.impl.Transport;
 
 /**
@@ -40,6 +41,13 @@ public class VersionResponse extends AbstractCAJResponseHandler {
 		InetSocketAddress responseFrom,
 		Transport transport,
 		ByteBuffer[] response) {
+		
+		try {
+			CATransport trn = (CATransport) transport;
+			trn.setMinorRevision((short) dataCount);
+		} catch(ClassCastException e) {
+			// assume BroadcastTransport, not CATransport
+		}
 
 		// if sequenceNumber is valid, set it
 		if (dataType != 0)

--- a/src/com/cosylab/epics/caj/impl/requests/VersionRequest.java
+++ b/src/com/cosylab/epics/caj/impl/requests/VersionRequest.java
@@ -16,6 +16,7 @@ package com.cosylab.epics.caj.impl.requests;
 
 import java.nio.ByteBuffer;
 
+import com.cosylab.epics.caj.impl.CAConstants;
 import com.cosylab.epics.caj.impl.Request;
 import com.cosylab.epics.caj.impl.Transport;
 
@@ -61,7 +62,7 @@ public class VersionRequest extends AbstractCARequest {
 	{
 		short isSequenceNumberValidCode = isSequenceNumberValid ? (short)1 : (short)0;
 		return insertCAHeader(transport, buffer,
-				(short)0, 0, isSequenceNumberValid ? isSequenceNumberValidCode : priority, transport.getMinorRevision(),
+				(short)0, 0, isSequenceNumberValid ? isSequenceNumberValidCode : priority, CAConstants.CA_MINOR_PROTOCOL_REVISION,
 				sequenceNumber, 0);
 	}
 

--- a/test/com/cosylab/epics/caj/util/test/InetAddressUtilTest.java
+++ b/test/com/cosylab/epics/caj/util/test/InetAddressUtilTest.java
@@ -90,7 +90,7 @@ public class InetAddressUtilTest extends TestCase {
     	        };
 
         list = InetAddressUtil.getSocketAddressList("192.168.0.12 192.168.0.13:8064", 7064, appendList);
-        assertEquals(3, list.length);
+        assertEquals(4, list.length);
         assertEquals(expectedAddreses[0], list[0]);
         assertEquals(expectedAddreses[1], list[1]);
         assertEquals(appendList[0], list[2]);


### PR DESCRIPTION
A collection of changes

* Fix up a test failure
* Support PV name search over TCP
* Send correct version number to peer in VERSION message
* Support put with payload size greater than 16kB

Configuration of the the TCP name server list is done through a new property key name ".name_servers".

There will be some log spam if/when a name server loses connection.